### PR TITLE
Explicitely call style_updated() during init

### DIFF
--- a/src/giggle-rev-list-view.c
+++ b/src/giggle-rev-list-view.c
@@ -1659,6 +1659,7 @@ giggle_rev_list_view_init (GiggleRevListView *rev_list_view)
 	GtkTreeViewColumn     *column;
 	gint                   font_size;
 	GtkCellRenderer       *cell;
+	GtkWidgetClass* widgetClass;
 
 	priv = GET_PRIV (rev_list_view);
 
@@ -1691,6 +1692,12 @@ giggle_rev_list_view_init (GiggleRevListView *rev_list_view)
 
 	gtk_tree_view_insert_column (GTK_TREE_VIEW (rev_list_view),
 				     priv->emblem_column, -1);
+
+	/*Force loading of emblems*/
+	widgetClass = GTK_WIDGET_GET_CLASS( rev_list_view );
+	if( widgetClass && widgetClass->style_updated ) { 
+		(*widgetClass->style_updated)(GTK_WIDGET(rev_list_view)); 
+	}
 
 	/* graph renderer */
 	priv->graph_column = gtk_tree_view_column_new ();


### PR DESCRIPTION
This is to force the load of giggle-specific icons. Otherwise, they are
not loaded until an actual style update...

(using GTK+ 3.16.7-0ubuntu3 as provided on official repositories for Ubuntu 15.10)

Somehow, this behavior changed from previous versions of GTK+ 3, since
the icons loading worked with ubuntu 14.04LTS (version of GTK+ 3
available on these repositories: 3.10.8-0ubuntu1.4)

This may not be the correct place to put this code, I'm not really used to GTK/GDK lifecycles (and C programming for that matter... more of a Java developper ;) )
